### PR TITLE
Update devDependencies / Fix JSHint seting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "lodash": "~2.4.1"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-jshint": "~0.2.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0",
-    "jshint-stylish": "~0.1.3",
-    "load-grunt-tasks": "~0.2.0",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-nodeunit": "~0.3.0",
+    "grunt": "~0.4.2",
+    "jshint-stylish": "~0.1.5",
+    "load-grunt-tasks": "~0.3.0",
     "grunt-continue": "0.0.1",
     "grunt-bump": "0.0.13",
     "grunt-conventional-changelog": "~1.0.0"

--- a/tasks/zschema.js
+++ b/tasks/zschema.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
         grunt.log.warn(file + " Warning: " + warning.message + " at " + warning.path);
       });
       cb(report.valid ? null : report);
-    }
+    };
 
     var validateSchema = function(schema, done) {
       var handler = _.bind(handleResults, this, schema, done);


### PR DESCRIPTION
I updated devDependencies of this project and fixed JSHint setting. Now there is no need to set the "ES5" option explicitly. (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/).
